### PR TITLE
pkg_tar: actually compress as gzip

### DIFF
--- a/puke
+++ b/puke
@@ -89,7 +89,7 @@ pkg_manifest() {
 }
 
 pkg_tar() {
-    tar pcf "$bin_dir/$pkg" -C "$pkg_dir" . || die "Failed to create package."
+    tar zpcf "$bin_dir/$pkg" -C "$pkg_dir" . || die "Failed to create package."
     log "Use '$0 install $name' to install the package."
 }
 


### PR DESCRIPTION
When using `tar pcf`, even if the file is given extension `.tar.gz`, it won't actually compress the file using `gzip`, just a regular `tar` archive.

Using previous command, `file -bi m4\#1.4.18-1.tar.gz` will output `application/x-tar` instead of the correct `application/x-gzip` for all gzip-compressed files.