### PR TITLE
Add capability to strip binaries

### DIFF
--- a/puke
+++ b/puke
@@ -92,8 +92,9 @@ pkg_strip() {
             ;;
             application/x-archive*) strip_opts="--strip-debug" ;;
             application/x-executable*) strip_opts="--strip-all" ;;
+            *) continue ;;
         esac
-        strip "$strip_opts" "$binary" 2>/dev/null
+        strip "$strip_opts" "$binary"
     done
 }
 

--- a/puke
+++ b/puke
@@ -85,13 +85,14 @@ pkg_build() {
 
 pkg_strip() {
     log "Stripping unneeded symbols from binaries and libraries"
+
     find "$pkg_dir" -type f | while read -r binary; do
-        case "$(file -bi "$binary")" in
+        case $(file -bi "$binary") in
             application/x-sharedlib*|application/x-pie-executable*)
-                strip_opts="--strip-unneeded"
+                strip_opts=--strip-unneeded
             ;;
-            application/x-archive*) strip_opts="--strip-debug" ;;
-            application/x-executable*) strip_opts="--strip-all" ;;
+            application/x-archive*) strip_opts=--strip-debug ;;
+            application/x-executable*) strip_opts=--strip-all ;;
             *) continue ;;
         esac
         strip "$strip_opts" "$binary"
@@ -162,7 +163,7 @@ args() {
             pkg_verify
             pkg_extract
             pkg_build
-            [ ! -f nostrip ] && pkg_strip
+            [ -f nostrip ] || pkg_strip
             pkg_manifest
             pkg_tar ;;
 

--- a/puke
+++ b/puke
@@ -83,6 +83,19 @@ pkg_build() {
     log "Sucessfully built $pkg." 2> "$pkg_db/$name/manifest"
 }
 
+pkg_strip() {
+    find "$pkg_dir" -type f | while read -r binary; do
+        case "$(file -bi "$binary")" in
+            application/x-sharedlib*|application/x-pie-executable*)
+                strip_opts="--strip-unneeded"
+            ;;
+            application/x-archive*) strip_opts="--strip-debug" ;;
+            application/x-executable*) strip_opts="--strip-all" ;;
+        esac
+        strip "$strip_opts" "$binary" 2>/dev/null
+    done
+}
+
 pkg_manifest() {
     (cd "$pkg_dir" && find ./*) | sed ss.ss | tac |
         tee manifest > "$pkg_db/$name/manifest"
@@ -147,6 +160,7 @@ args() {
             pkg_verify
             pkg_extract
             pkg_build
+            pkg_strip
             pkg_manifest
             pkg_tar ;;
 

--- a/puke
+++ b/puke
@@ -84,6 +84,7 @@ pkg_build() {
 }
 
 pkg_strip() {
+    log "Stripping unneeded symbols from binaries and libraries"
     find "$pkg_dir" -type f | while read -r binary; do
         case "$(file -bi "$binary")" in
             application/x-sharedlib*|application/x-pie-executable*)
@@ -160,7 +161,7 @@ args() {
             pkg_verify
             pkg_extract
             pkg_build
-            pkg_strip
+            [ ! -f nostrip ] && pkg_strip
             pkg_manifest
             pkg_tar ;;
 


### PR DESCRIPTION
Many (if not all) binaries have debugging symbols after compiled, most of them are not essential when we're not debugging anything. This PR adds the capability to strip binaries by default. While it won't have much impact if the binaries is still packaged, the binaries will take less (in some cases, much less) disk space if installed (e.g. `usr/bin/m4` takes 231376 bytes stripped vs 1252640 bytes unstripped).

For some packages that should not be stripped at all, an optional empty `nostrip` file in their respective package "pkgbuild" directory can be added. (Note: I don't know if adding options this way is good enough, if you prefer another way (e.g. an optional sourceable `options` file which contains `nostrip=YES`), just say it.)

All of the options are taken from Arch's default `/etc/makepkg.conf` options.