### PR TITLE
pkg_build: Remove unneeded redirection

### DIFF
--- a/puke
+++ b/puke
@@ -80,7 +80,7 @@ pkg_extract() {
 pkg_build() {
     (cd "$mak_dir"; "$OLDPWD/build" "$pkg_dir") || die "Build failed."
     cp -Rf "$rep_dir/$name" "$pkg_db"
-    log "Sucessfully built $pkg." 2> "$pkg_db/$name/manifest"
+    log "Sucessfully built $pkg."
 }
 
 pkg_strip() {


### PR DESCRIPTION
I'm not sure what does the stderr redirection do in this line.

The log function's output is to stdout (stderr in this case receives nothing), and [`pkg_manifest` rewrites the whole `manifest` file anyway](https://github.com/konimex/kiss/blob/8db84bf174077b50b613007a243dfe13e22e29a6/puke#L107).