### PR TITLE
pkg_makedepends: add support

### DIFF
--- a/kiss
+++ b/kiss
@@ -52,6 +52,18 @@ pkg_depends() {
     done 2>/dev/null < depends
 }
 
+pkg_makedepends() {
+    while read -r dep; do
+        pkg_list "$dep" ||
+            case $missing in
+                *" $dep,"*) ;;
+                *) missing="$missing $dep,"
+                   pkg_setup "$dep"
+                   pkg_makedepends ;;
+            esac
+    done 2>/dev/null < makedepends
+}
+
 pkg_sources() {
     while read -r src _; do
         case $(source_type "$src"; echo $?) in
@@ -185,6 +197,9 @@ args() {
             pkg_depends
 
             [ -n "$missing" ] && die "Missing dependencies:${missing%,}"
+
+            pkg_makedepends
+            [ -n "$missing" ] && die "Missing makedependencies:${missing%,}"
 
             pkg_sources
             pkg_verify


### PR DESCRIPTION
## Rationale

When building packages, `makedepends` would be needed. Currently `kiss` combines `makedepends` and `depends`, this makes sense for a *source-based* packaging system, but for a ready-to-go binary `tar` package shared by someone over the net (well, kiss does tar its packages, unlike, say, portage IIRC), this would effectively mean bloatware, and for people who want to make their system as small as possible, an installed `makedepends` can be bloatware.

But even on Gentoo, `BDEPEND`  and `RDEPEND` (for runtime deps) are separated. So I think it would make sense if we separate makedepends and true runtime dependencies.