### PR TITLE
install: add dependency check

### DIFF
--- a/kiss
+++ b/kiss
@@ -200,7 +200,9 @@ args() {
             pkg_checksum
             log "Generated checksums." ;;
 
-        i*) pkg_install ;;
+        i*) pkg_depends
+            pkg_install ;;
+
         l*) pkg_list "$2" ;;
         r*) pkg_remove || die "Package '$name' not installed" ;;
         u*) pkg_updates ;;


### PR DESCRIPTION
## Rationale

In case of a package already exist in `$bin_dir` if it isn't built in that system (e.g. by copying the tar file manually from another `kiss` instance to `$bin_dir`), don't blindly install it but check if the depends are properly installed. Otherwise the binaries won't run properly.