### PR TITLE
kiss: Fix pkg_install if coreutils is reinstalled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See: <https://github.com/kissx/packages>
 
 POSIX `coreutils`:
 
-- `cat`, `cp`, `find`, `mkdir`, `sh`, `rm`, `rmdir`, `sed`, `tee`
+- `cat`, `command`, `cp`, `find`, `mkdir`, `sh`, `rm`, `rmdir`, `sed`, `tee`
 
 Other utilities:
 

--- a/kiss
+++ b/kiss
@@ -137,8 +137,13 @@ pkg_tar() {
 pkg_install() {
     [ -f "$bin_dir/$pkg" ] || args b "$name"
 
+    # Create a backup of 'tar' so it isn't removed during
+    # package installation.
+    cp "$(command -v tar)" "$cac_dir"
+
     pkg_remove "$name"
-    tar pxvf "$bin_dir/$pkg" -k -C "$sys_dir/" 2>/dev/null
+    "$cac_dir/tar" kpxvf "$bin_dir/$pkg" -C "$sys_dir/"
+    rm "$cac_dir/tar"
 
     "$sys_db/$name/post-install" 2>/dev/null
 
@@ -148,13 +153,18 @@ pkg_install() {
 pkg_remove() {
     pkg_list "$name" || return 1
 
+    # Create a backup of 'rm' and 'rmdir' so they aren't
+    # removed during package installation.
+    cp "$(command -v rm)"    "$cac_dir"
+    cp "$(command -v rmdir)" "$cac_dir"
+
     while read -r file; do
         [ "${file%/*}" = /etc ] && continue
 
         if [ -d "$sys_dir$file" ]; then
-            rmdir "$sys_dir$file" 2>/dev/null || continue
+            "$cac_dir/rmdir" "$sys_dir$file" 2>/dev/null || continue
         else
-            rm -f -- "$sys_dir$file" || log "Failed to remove $file."
+            "$cac_dir/rm" -f -- "$sys_dir$file" || log "Failed to remove $file."
         fi && log "Removed $file"
     done < "$sys_db/$name/manifest"
 }

--- a/kiss
+++ b/kiss
@@ -167,6 +167,9 @@ pkg_remove() {
             "$cac_dir/rm" -f -- "$sys_dir$file" || log "Failed to remove $file."
         fi && log "Removed $file"
     done < "$sys_db/$name/manifest"
+
+    # Use the backup of 'rm' to remove 'rmdir' and itself.
+    "$cac_dir/rm" "$cac_dir/rmdir" "$cac_dir/rm"
 }
 
 pkg_updates() {

--- a/kiss
+++ b/kiss
@@ -154,7 +154,7 @@ pkg_remove() {
     pkg_list "$name" || return 1
 
     # Create a backup of 'rm' and 'rmdir' so they aren't
-    # removed during package installation.
+    # removed during package removal.
     cp "$(command -v rm)"    "$cac_dir"
     cp "$(command -v rmdir)" "$cac_dir"
 


### PR DESCRIPTION
Running `pkg_remove` prior to `pkg_install` had the benefit of removing any files in the system that **aren't** in the new version of the package (but exist in the currently installed version). It also has the benefit of **not** overwriting files owned by a different package (it instead skips them).

This PR creates copies of `rm`, `rmdir` and `tar` (and removes them afterwards) ensuring the commands will always be available.

This seems like the "least bad" solution to the problem as it prevents stray files between package upgrades. (We can later add a check for conflicting files between multiple packages and abort)

I think we should also consider setting `set -e` globally in the script. 