### PR TITLE
kiss: Added package conflicts.

### DIFF
--- a/kiss
+++ b/kiss
@@ -80,7 +80,7 @@ pkg_checksum() {
 
 pkg_verify() {
     [ "$(pkg_checksum /dev/stdout)" = "$(cat checksums)" ] ||
-        die "Checksum mismatch, run '$0 checksum $name' to update checksums."
+        die "Checksum mismatch, run '$kiss checksum $name'."
 }
 
 pkg_extract() {
@@ -131,7 +131,7 @@ pkg_manifest() {
 
 pkg_tar() {
     tar zpcf "$bin_dir/$pkg" -C "$pkg_dir" . || die "Failed to create package."
-    log "Use '$0 install $name' to install the package."
+    log "Use '$kiss install $name' to install the package."
 }
 
 pkg_install() {
@@ -196,7 +196,8 @@ pkg_list() {
 args() {
     case $1 in b*|c*|i*|r*) pkg_setup "${2-null}"; esac
     case $1 in
-        b*) [ -f checksums ] || die "Checksums missing, run '$0 checksum $name'"
+        b*) [ -f checksums ] ||
+                die "Checksums missing, run '$kiss checksum $name'"
 
             pkg_depends
 
@@ -223,7 +224,7 @@ args() {
         r*) pkg_remove || die "Package '$name' not installed" ;;
         u*) pkg_updates ;;
 
-        *)  log "${0##*/} [b|c|i|l|r|u] [pkg]" \
+        *)  log "$kiss [b|c|i|l|r|u] [pkg]" \
                 "build:     Build a package." \
                 "checksum:  Generate checksums." \
                 "install:   Install a package (Runs build if needed)." \
@@ -235,6 +236,7 @@ args() {
 
 main() {
     trap 'rm -rf -- "$mak_dir" "$pkg_dir"' EXIT INT
+    kiss=${0##*/}
 
     [ -z "$KISS_PATH" ] &&
         die "Set \$KISS_PATH to a repository location."
@@ -242,12 +244,12 @@ main() {
     [ -z "$KISS_ROOT" ] && [ "$(id -u)" != 0 ] &&
         die "\$KISS_ROOT is set to '/' so you need to be root."
 
-    mkdir -p "${cac_dir:=${XDG_CACHE_HOME:=$HOME/.cache}/${0##*/}}" \
+    mkdir -p "${cac_dir:=${XDG_CACHE_HOME:=$HOME/.cache}/$kiss}" \
              "${src_dir:=$cac_dir/sources}" \
              "${mak_dir:=$cac_dir/build}" \
              "${bin_dir:=$cac_dir/bin}" \
-             "${pkg_db:=${pkg_dir:=$cac_dir/pkg}/var/db/${0##*/}}" \
-             "${sys_db:=${sys_dir:=$KISS_ROOT}/var/db/${0##*/}}" ||
+             "${pkg_db:=${pkg_dir:=$cac_dir/pkg}/var/db/$kiss}" \
+             "${sys_db:=${sys_dir:=$KISS_ROOT}/var/db/$kiss}" ||
              die "Couldn't create directories."
 
     args "$@"

--- a/kiss
+++ b/kiss
@@ -125,8 +125,11 @@ pkg_strip() {
 }
 
 pkg_manifest() {
-    (cd "$pkg_dir" && find ./*) | sed -e ss.ss -e '1!G;h;$!d' |
-        tee manifest > "$pkg_db/$name/manifest"
+    # Store the file and directory list of the package.
+    # Directories have a trailing '/' and the list is sorted in reverse.
+    (cd "$pkg_dir" && {
+        find ./* -type d -print | sed 's!$!/!'; find . \! -type d
+    }) | sort -r | sed -e ss.ss | tee manifest > "$pkg_db/$name/manifest"
 }
 
 pkg_tar() {
@@ -139,9 +142,9 @@ pkg_conflicts() {
 
     # Extract manifest from tarball and strip directories.
     tar xf "$bin_dir/$pkg" "./var/db/$kiss/$name/manifest" -O |
-        while read -r line; do
-            [ -f "$line" ] && printf '%s\n' "$line" >> "$cac_dir/manifest"
-        done
+    while read -r line; do
+        [ "${line%%*/}" ] && printf '%s\n' "$line" >> "$cac_dir/manifest"
+    done
 
     # Compare extracted manifest to all installed manifests.
     # If there are matching lines (files) there's a package
@@ -152,8 +155,6 @@ pkg_conflicts() {
         grep -Fxf "$cac_dir/manifest" "$db/manifest" &&
             die "Package '$name' conflicts with '${db##*/}'."
     done
-
-    rm "$cac_dir/manifest"
 }
 
 pkg_install() {
@@ -261,7 +262,7 @@ args() {
 }
 
 main() {
-    trap 'rm -rf -- "$mak_dir" "$pkg_dir"' EXIT INT
+    trap 'rm -rf -- "$mak_dir" "$pkg_dir" "$cac_dir/manifest"' EXIT INT
     kiss=${0##*/}
 
     [ -z "$KISS_PATH" ] &&

--- a/kiss
+++ b/kiss
@@ -131,9 +131,8 @@ pkg_strip() {
 pkg_manifest() {
     # Store the file and directory list of the package.
     # Directories have a trailing '/' and the list is sorted in reverse.
-    (cd "$pkg_dir" && {
-        find ./* -type d -print | sed 's!$!/!'; find . \! -type d
-    }) | sort -r | sed -e ss.ss | tee manifest > "$pkg_db/$name/manifest"
+    (cd "$pkg_dir" && find ./* -type d -exec printf '%s/\n' {} + -or -print) |
+        sort -r | sed -e ss.ss | tee manifest > "$pkg_db/$name/manifest"
 }
 
 pkg_tar() {

--- a/kiss
+++ b/kiss
@@ -134,15 +134,41 @@ pkg_tar() {
     log "Use '$kiss install $name' to install the package."
 }
 
+pkg_conflicts() {
+    log "Checking for package conflicts."
+
+    # Extract manifest from tarball and strip directories.
+    tar xf "$bin_dir/$pkg" "./var/db/$kiss/$name/manifest" -O |
+        while read -r line; do
+            [ -f "$line" ] && printf '%s\n' "$line" >> "$cac_dir/manifest"
+        done
+
+    # Compare extracted manifest to all installed manifests.
+    # If there are matching lines (files) there's a package
+    # conflict.
+    for db in "$sys_db"/*; do
+        [ "$name" = "${db##*/}" ] && continue
+
+        grep -Fxf "$cac_dir/manifest" "$db/manifest" &&
+            die "Package '$name' conflicts with '${db##*/}'."
+    done
+
+    rm "$cac_dir/manifest"
+}
+
 pkg_install() {
     [ -f "$bin_dir/$pkg" ] || args b "$name"
+
+    pkg_conflicts
 
     # Create a backup of 'tar' so it isn't removed during
     # package installation.
     cp "$(command -v tar)" "$cac_dir"
 
+    log "Removing previous version of package if it exists."
     pkg_remove "$name"
-    "$cac_dir/tar" kpxvf "$bin_dir/$pkg" -C "$sys_dir/"
+
+    "$cac_dir/tar" kpxf "$bin_dir/$pkg" -C "$sys_dir/"
     rm "$cac_dir/tar"
 
     "$sys_db/$name/post-install" 2>/dev/null


### PR DESCRIPTION
Before a package installation this compares the tarball's manifest to all installed package's manifests and aborts if there is a conflict. This allows us to "dynamically" detect conflicts and remove the need for a `conflicts` file.

To workaround the issue of false positives with directories, directories are stripped from the tarball's manifest. This basically means that only matching **files** are checked for conflicts which is fine.

Closes #11 