### PR TITLE
pkg_manifest: sort before writing to manifest file

### DIFF
--- a/kiss
+++ b/kiss
@@ -126,7 +126,7 @@ pkg_strip() {
 
 pkg_manifest() {
     (cd "$pkg_dir" && find ./*) | sed -e ss.ss -e '1!G;h;$!d' |
-        tee manifest > "$pkg_db/$name/manifest"
+        sort | tee manifest > "$pkg_db/$name/manifest"
 }
 
 pkg_tar() {


### PR DESCRIPTION
Rewriting manifest can be very massive, since `find` will just get whatever comes in first. [Gettext](https://github.com/kissx/packages/commit/b6531bb24a36174f7ec497135ed1bce503f63c17#diff-51174322c1306c4912143c1337533b10) has a long diff in `manifest` alone. After this commit, I hope we have one last massive manifest diff changes for each package, and the manifest changes will be reserved for the new/deleted file.